### PR TITLE
Add bundle size calculator

### DIFF
--- a/scripts/calculate-bundle-size.sh
+++ b/scripts/calculate-bundle-size.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+TMP=./scripts/.tmp
+BIN=./node_modules/.bin
+WEBPACK=$BIN/webpack
+BROWSERIFY=$BIN/browserify
+UGLIFY=$BIN/uglifyjs
+ENTRYPOINT=./index.js
+
+function filesize {
+  cat $1 | wc -c
+}
+
+function browserify {
+  $BROWSERIFY $ENTRYPOINT --screw-ie8 --outfile $TMP/browserify.js
+}
+
+function webpack {
+  $WEBPACK --entry $ENTRYPOINT --output-filename $TMP/webpack.js > /dev/null
+}
+
+function minify {
+  $UGLIFY --compress warnings=false --mangle --output $TMP/browserify.min.js $TMP/browserify.js 2>&1 /dev/null
+  $UGLIFY --compress warnings=false --mangle --output $TMP/webpack.min.js $TMP/webpack.js 2>&1 /dev/null
+}
+
+function gzipped {
+  gzip webpack.min.js
+  gzip browserify.min.js
+}
+
+function getSizes {
+  browserify
+  webpack
+  minify
+
+  pushd $TMP > /dev/null
+
+  for i in *.js; do
+    echo "$i: $(filesize $i)"
+  done
+
+  gzipped
+
+  for i in *.gz; do
+    echo "$i: $(filesize $i)"
+  done
+
+  popd > /dev/null
+}
+
+mkdir -p $TMP
+getSizes
+rm -rf $TMP


### PR DESCRIPTION
Example output:

```
browserify.js:     4765
browserify.min.js:     2835
webpack.js:     5641
webpack.min.js:     1977
browserify.min.js.gz:      967
webpack.min.js.gz:      674
```
