### PR TITLE
Fix various issues with the non-native slice implementation

### DIFF
--- a/src/slice.js
+++ b/src/slice.js
@@ -1,23 +1,33 @@
 var isNative = require('./util/isNative')
 var slice = Array.prototype.slice
+
 var slicer = isNative(slice)
   ? function nativeSlice (array, begin, end) {
     return slice.call(array, begin, end)
   }
-  : function slice (array, start, end) {
-    var l = array.length
+  : function slice(array, start, end) {
+    // Copied almost exactly from https://github.com/lodash/lodash/blob/master/slice.js
+    var length = array == null ? 0 : array.length
+    if (!length) {
+      return []
+    }
 
-    // Handle negative values for `begin`
-    if (start < 0) start = Math.max(0, l + start)
+    if (start < 0) {
+      start = -start > length ? 0 : (length + start)
+    }
+    end = end > length ? length : end
+    if (end < 0) {
+      end += length
+    }
+    length = start > end ? 0 : ((end - start) >>> 0)
+    start >>>= 0
 
-    // Handle negative values for `end`
-    var size = (end < 0 ? l + end : Math.min(end, l)) - start
-
-    if (size < 1) return []
-
-    var sliced = new Array(size)
-    for (var i = size - 1; i >= start; i--) sliced[i] = array[i]
-    return sliced
+    var index = -1
+    var result = new Array(length)
+    while (++index < length) {
+      result[index] = array[index + start]
+    }
+    return result
   }
 
 module.exports = function slice (array, begin, end) {


### PR DESCRIPTION
I've been hunting down the source of this bug: https://sentry.qutics.com/sentry/ssg-visitor-engine/issues/58/

I believe I've found it. Our non-native slice implementation is pretty fucked. Right now:
![screen shot 2018-03-19 at 15 07 59](https://user-images.githubusercontent.com/621323/37603859-79dcb746-2b87-11e8-9a9f-faaa41ad7b5f.png)

Issues fixed:
- If the array had length 1, it would return an empty array - wat
- The slicing started at the length of the array, instead of the final index of the array
- The slicing stopped before it hit index 0